### PR TITLE
Fixed goprotobuf import path

### DIFF
--- a/bong/client.go
+++ b/bong/client.go
@@ -9,7 +9,7 @@ package bong
 
 import (
 	"bufio"
-	"code.google.com/p/goprotobuf/proto"
+	"github.com/golang/protobuf"
 	"errors"
 	"fmt"
 	"io"

--- a/bong/rpc.pb.go
+++ b/bong/rpc.pb.go
@@ -4,7 +4,7 @@
 
 package bong
 
-import proto "code.google.com/p/goprotobuf/proto"
+import proto "github.com/golang/protobuf"
 import json "encoding/json"
 import math "math"
 

--- a/bong/server.go
+++ b/bong/server.go
@@ -9,7 +9,7 @@ package bong
 
 import (
 	"bufio"
-	"code.google.com/p/goprotobuf/proto"
+	"github.com/golang/protobuf"
 	"errors"
 	"fmt"
 	"io"


### PR DESCRIPTION
https://groups.google.com/forum/#!topic/golang-nuts/oXkI5cipsuI

`code.google.com/p/goprotobuf/proto` is no longer available, it redirects to github breaking go get code fetching.